### PR TITLE
configure fluentd-ds serviceaccount

### DIFF
--- a/labs/4.1/config/fluentd-ds.yaml
+++ b/labs/4.1/config/fluentd-ds.yaml
@@ -15,6 +15,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: fluentd
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
The fluentd daemonset needs to use the service account specifed in the
clusterrolebinding, otherwise it gets stuck in a crash loop due to
being unable to access the Kubernetes API:

    2017-12-05 19:48:21 +0000 [error]: config error file="/fluentd/etc/fluent.conf"
    error="Exception encountered fetching metadata from Kubernetes API endpoint:
    pods is forbidden: User \"system:serviceaccount:logging:default\" cannot list
    pods at the cluster scope ({\"kind\":\"Status\",\"apiVersion\":\"v1\",
    \"metadata\":{},\"status\":\"Failure\",\"message\":\"pods is forbidden: User
    \\\"system:serviceaccount:logging:default\\\" cannot list pods at the cluster
    scope\",\"reason\":\"Forbidden\",\"details\":{\"kind\":\"pods\"},\"code\":403}\n)"
    2017-12-05 19:48:21 +0000 [info]: process finished code=256
    2017-12-05 19:48:21 +0000 [warn]: process died within 1 second. exit.